### PR TITLE
Add metadata and ephemeral key route

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,12 +16,6 @@ plugins {
     jacoco
 }
 
-repositories {
-    mavenCentral()
-    mavenLocal()
-    maven { url = uri("https://jitpack.io") }
-}
-
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -35,6 +29,7 @@ dependencies {
     implementation(libs.bouncy.castle)
     implementation(libs.arrow.core)
     implementation(libs.arrow.fx.coroutines)
+    implementation(libs.zkp)
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ foojay = "0.8.0"
 springboot = "3.2.4"
 springDependencyManagement = "1.1.4"
 spotless = "6.25.0"
-java = "17"
+java = "21"
 kotlinxSerialization = "1.6.3"
 oauth2OidcSdk = "11.10.1"
 presentationExchange = "0.3.0"
@@ -15,6 +15,7 @@ arrow = "1.2.4"
 sonarqube = "5.0.0.4638"
 dependencycheck = "9.1.0"
 jacoco = "0.8.11"
+zkp = "main-SNAPSHOT"
 
 
 [libraries]
@@ -25,6 +26,7 @@ presentation-exchange = { module = "eu.europa.ec.eudi:eudi-lib-jvm-presentation-
 bouncy-castle = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle" }
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
+zkp = { group = "com.github.TICESoftware", name = "ZKP", version.ref = "zkp" }
 
 [plugins]
 foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.6.0")
-
 }
 
 dependencyResolutionManagement {
@@ -10,9 +9,7 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://jitpack.io")
         }
-
     }
 }
 
 rootProject.name = "eudi-srv-web-verifier-endpoint-23220-4-kt"
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,18 @@
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.6.0")
+
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+        }
+
+    }
 }
 
 rootProject.name = "eudi-srv-web-verifier-endpoint-23220-4-kt"
+

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -122,6 +122,7 @@ internal fun beans(clock: Clock) = beans {
     bean { GenerateEphemeralEncryptionKeyPairNimbus }
     bean { GetWalletResponseLive(ref()) }
     bean { GetJarmJwksLive(ref()) }
+    bean { PostZkpJwkRequestLive(ref(), ref()) }
 
     //
     // Scheduled
@@ -144,6 +145,7 @@ internal fun beans(clock: Clock) = beans {
             ref(),
             ref(),
             ref<VerifierConfig>().clientIdScheme.jarSigning.key,
+            ref(),
         )
         val verifierApi = VerifierApi(ref(), ref())
         val staticContent = StaticContent()
@@ -349,7 +351,11 @@ private fun Environment.clientMetaData(publicUrl: String): ClientMetaData {
             authorizationEncryptedResponseAlg,
             authorizationEncryptedResponseEnc,
         ) ?: defaultJarmOption,
-        zkpOption = WalletApi.requestZkpKey(publicUrl)
+        zkpOption = WalletApi.requestZkpKey(publicUrl),
+        vpFormats = mapOf(
+            "vc+sd-jwt+zkp" to VpFormat(listOf("secp256r1-sha256")),
+            "mso_mdoc+zkp" to VpFormat(listOf("secp256r1-sha256"))
+        )
     )
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -354,8 +354,8 @@ private fun Environment.clientMetaData(publicUrl: String): ClientMetaData {
         zkpOption = WalletApi.requestZkpKey(publicUrl),
         vpFormats = mapOf(
             "vc+sd-jwt+zkp" to VpFormat(listOf("secp256r1-sha256")),
-            "mso_mdoc+zkp" to VpFormat(listOf("secp256r1-sha256"))
-        )
+            "mso_mdoc+zkp" to VpFormat(listOf("secp256r1-sha256")),
+        ),
     )
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/VerifierContext.kt
@@ -102,6 +102,7 @@ internal fun beans(clock: Clock) = beans {
             WalletApi.requestJwtByReference(env.publicUrl()),
             WalletApi.presentationDefinitionByReference(env.publicUrl()),
             ref(),
+            WalletApi.requestZkpKey(env.publicUrl()),
         )
     }
 
@@ -351,11 +352,6 @@ private fun Environment.clientMetaData(publicUrl: String): ClientMetaData {
             authorizationEncryptedResponseAlg,
             authorizationEncryptedResponseEnc,
         ) ?: defaultJarmOption,
-        zkpOption = WalletApi.requestZkpKey(publicUrl),
-        vpFormats = mapOf(
-            "vc+sd-jwt+zkp" to VpFormat(listOf("secp256r1-sha256")),
-            "mso_mdoc+zkp" to VpFormat(listOf("secp256r1-sha256")),
-        ),
     )
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
@@ -64,7 +64,7 @@ class WalletApi(
         GET(JARM_JWK_SET_PATH, this@WalletApi::handleGetJarmJwks)
         POST(
             ZKP_JWK_SET_PATH,
-            this@WalletApi::handlePostZkpJwk
+            this@WalletApi::handlePostZkpJwk,
         )
     }
 
@@ -119,7 +119,8 @@ class WalletApi(
                 logger.info(
                     response.fold(
                         { "Verifier UI will poll for Wallet Response" },
-                        { "Wallet must redirect to ${it.redirectUri}" })
+                        { "Wallet must redirect to ${it.redirectUri}" },
+                    ),
                 )
                 ok().json().bodyValueAndAwait(response.getOrElse { JsonObject(emptyMap()) })
             },

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/WalletApi.kt
@@ -45,6 +45,7 @@ class WalletApi(
     private val postWalletResponse: PostWalletResponse,
     private val getJarmJwks: GetJarmJwks,
     private val signingKey: JWK,
+    private val postZkpJwkRequest: PostZkpJwkRequest,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(WalletApi::class.java)
@@ -61,6 +62,10 @@ class WalletApi(
         )
         GET(GET_PUBLIC_JWK_SET_PATH) { _ -> handleGetPublicJwkSet() }
         GET(JARM_JWK_SET_PATH, this@WalletApi::handleGetJarmJwks)
+        POST(
+            ZKP_JWK_SET_PATH,
+            this@WalletApi::handlePostZkpJwk
+        )
     }
 
     /**
@@ -111,7 +116,11 @@ class WalletApi(
         outcome.fold(
             ifRight = { response ->
                 logger.info("PostWalletResponse processed")
-                logger.info(response.fold({ "Verifier UI will poll for Wallet Response" }, { "Wallet must redirect to ${it.redirectUri}" }))
+                logger.info(
+                    response.fold(
+                        { "Verifier UI will poll for Wallet Response" },
+                        { "Wallet must redirect to ${it.redirectUri}" })
+                )
                 ok().json().bodyValueAndAwait(response.getOrElse { JsonObject(emptyMap()) })
             },
             ifLeft = { error ->
@@ -144,6 +153,29 @@ class WalletApi(
                 .contentType(MediaType.parseMediaType(JWKSet.MIME_TYPE))
                 .bodyValueAndAwait(queryResponse.value.toJSONObject(true))
         }
+    }
+
+    /**
+     * Handles the POST request for fetching the ephemeral keys used for the ZKP.
+     */
+
+    private suspend fun handlePostZkpJwk(request: ServerRequest): ServerResponse = try {
+        logger.info("Handling PostZkpJwk ...")
+        val requestId = request.requestId()
+        val outcome = either { postZkpJwkRequest(request, requestId) }
+        outcome.fold(
+            ifRight = { jwkSet: List<EphemeralKeyResponse> ->
+                logger.info("PostZkpJwk processed")
+                ok().json().bodyValueAndAwait(jwkSet)
+            },
+            ifLeft = { error: ZkpJwkError ->
+                logger.error("$error while handling post of ZkpJwk")
+                badRequest().buildAndAwait()
+            },
+        )
+    } catch (t: SerializationException) {
+        logger.error("While handling post of ZkpJwk, failed to decode JSON", t)
+        badRequest().buildAndAwait()
     }
 
     companion object {

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbus.kt
@@ -134,8 +134,6 @@ class SignRequestObjectNimbus : SignRequestObject {
             jwkSet?.let { this.jwkSet = it }
             jwkSetUri?.let { this.jwkSetURI = it.toURI() }
             setCustomField("subject_syntax_types_supported", c.subjectSyntaxTypesSupported)
-            setCustomField("vp_formats", c.vpFormats)
-            setCustomField("vp_token_zkp_key_uri", (c.zkpOption as ByReference).buildUrl)
 
             if ("direct_post.jwt" == responseMode) {
                 c.jarmOption.jwsAlg?.let { setCustomField("authorization_signed_response_alg", it) }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbus.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/jose/SignRequestObjectNimbus.kt
@@ -134,7 +134,7 @@ class SignRequestObjectNimbus : SignRequestObject {
             jwkSet?.let { this.jwkSet = it }
             jwkSetUri?.let { this.jwkSetURI = it.toURI() }
             setCustomField("subject_syntax_types_supported", c.subjectSyntaxTypesSupported)
-            setCustomField("vp_formats", "TODO") // needs to be added to ClientMetadata class etc.
+            setCustomField("vp_formats", c.vpFormats)
             setCustomField("vp_token_zkp_key_uri", (c.zkpOption as ByReference).buildUrl)
 
             if ("direct_post.jwt" == responseMode) {

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/persistence/PresentationInMemoryRepo.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/out/persistence/PresentationInMemoryRepo.kt
@@ -40,6 +40,7 @@ class PresentationInMemoryRepo(
             is Presentation.Requested -> p.requestId
             is Presentation.RequestObjectRetrieved -> p.requestId
             is Presentation.Submitted -> p.requestId
+            is Presentation.ZkpState -> p.requestId
             is Presentation.TimedOut -> null
         }
         LoadPresentationByRequestId { requestId ->

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
@@ -138,7 +138,7 @@ sealed interface Presentation {
     /**
      * A presentation process that has been just requested
      */
-    class Requested(
+    data class Requested(
         override val id: TransactionId,
         override val initiatedAt: Instant,
         override val type: PresentationType,
@@ -148,6 +148,7 @@ sealed interface Presentation {
         val responseMode: ResponseModeOption,
         val presentationDefinitionMode: EmbedOption<RequestId>,
         val getWalletResponseMethod: GetWalletResponseMethod,
+        val zkpOption: EmbedOption<RequestId>? = null,
     ) : Presentation
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/Presentation.kt
@@ -268,7 +268,6 @@ sealed interface Presentation {
         }
     }
 
-
     class TimedOut private constructor(
         override val id: TransactionId,
         override val initiatedAt: Instant,
@@ -321,7 +320,6 @@ sealed interface Presentation {
         }
     }
 }
-
 
 fun Presentation.isExpired(at: Instant): Boolean {
     fun Instant.isBeforeOrEqual(at: Instant) = isBefore(at) || this == at

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
@@ -77,10 +77,6 @@ sealed interface JarmOption {
     ) : JarmOption
 }
 
-data class VpFormat(
-    val proofType: List<String>,
-)
-
 /**
  * By OpenID Connect Dynamic Client Registration specification
  *
@@ -93,8 +89,6 @@ data class ClientMetaData(
     val idTokenEncryptedResponseEnc: String,
     val subjectSyntaxTypesSupported: List<String>,
     val jarmOption: JarmOption,
-    val zkpOption: EmbedOption<RequestId>,
-    val vpFormats: Map<String, Any>,
 )
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
@@ -78,7 +78,7 @@ sealed interface JarmOption {
 }
 
 data class VpFormat(
-    val proofType: List<String>
+    val proofType: List<String>,
 )
 
 /**
@@ -94,7 +94,7 @@ data class ClientMetaData(
     val subjectSyntaxTypesSupported: List<String>,
     val jarmOption: JarmOption,
     val zkpOption: EmbedOption<RequestId>,
-    val vpFormats: Map<String, VpFormat>
+    val vpFormats: Map<String, Any>,
 )
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/domain/VerifierConfig.kt
@@ -77,6 +77,10 @@ sealed interface JarmOption {
     ) : JarmOption
 }
 
+data class VpFormat(
+    val proofType: List<String>
+)
+
 /**
  * By OpenID Connect Dynamic Client Registration specification
  *
@@ -90,6 +94,7 @@ data class ClientMetaData(
     val subjectSyntaxTypesSupported: List<String>,
     val jarmOption: JarmOption,
     val zkpOption: EmbedOption<RequestId>,
+    val vpFormats: Map<String, VpFormat>
 )
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostZkpJwkRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostZkpJwkRequest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.europa.ec.eudi.verifier.endpoint.port.input
 
 import arrow.core.raise.Raise
@@ -14,7 +29,6 @@ import java.security.interfaces.ECPublicKey
 import java.security.spec.X509EncodedKeySpec
 import java.util.*
 
-
 sealed interface ZkpJwkError {
     data class ProcessingError(val message: String, val error: Throwable) : ZkpJwkError
 }
@@ -23,7 +37,7 @@ data class ChallengeRequest(
     val id: String,
     val digest: String,
     val r: String,
-    val proofType: String
+    val proofType: String,
 )
 
 data class EphemeralKeyResponse(
@@ -32,7 +46,7 @@ data class EphemeralKeyResponse(
     val kty: String,
     val crv: String,
     val x: String,
-    val y: String
+    val y: String,
 )
 
 private const val publicKeyPEM = """
@@ -56,10 +70,8 @@ class PostZkpJwkRequestLive(
     private val storePresentation: StorePresentation,
 ) : PostZkpJwkRequest {
 
-
     context(Raise<ZkpJwkError>)
     override suspend operator fun invoke(request: ServerRequest, requestId: RequestId): List<EphemeralKeyResponse> {
-
         val pem = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", "")
         val keyBytes = Base64.getDecoder().decode(pem)
         val keySpec = X509EncodedKeySpec(keyBytes)
@@ -93,7 +105,7 @@ class PostZkpJwkRequestLive(
                 kty = "EC",
                 crv = "P-256",
                 x = x,
-                y = y
+                y = y,
             )
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostZkpJwkRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostZkpJwkRequest.kt
@@ -1,0 +1,100 @@
+package eu.europa.ec.eudi.verifier.endpoint.port.input
+
+import arrow.core.raise.Raise
+import eu.europa.ec.eudi.verifier.endpoint.domain.Presentation
+import eu.europa.ec.eudi.verifier.endpoint.domain.RequestId
+import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.LoadPresentationByRequestId
+import eu.europa.ec.eudi.verifier.endpoint.port.out.persistence.StorePresentation
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.awaitBody
+import software.tice.ChallengeRequestData
+import software.tice.ZKPVerifier
+import java.security.KeyFactory
+import java.security.interfaces.ECPublicKey
+import java.security.spec.X509EncodedKeySpec
+import java.util.*
+
+
+sealed interface ZkpJwkError {
+    data class ProcessingError(val message: String, val error: Throwable) : ZkpJwkError
+}
+
+data class ChallengeRequest(
+    val id: String,
+    val digest: String,
+    val r: String,
+    val proofType: String
+)
+
+data class EphemeralKeyResponse(
+    val id: String,
+    val kid: String,
+    val kty: String,
+    val crv: String,
+    val x: String,
+    val y: String
+)
+
+private const val publicKeyPEM = """
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsFu+Nl1NXvC8RM/IXiXLu8MVA7X7
+mXT3Jnvb5uHxK/5JZxi0wqzGQ11KjZvUF8Ftc/oGAzWdPmTwGEg5ZD293g==
+-----END PUBLIC KEY-----
+"""
+
+/**
+ * Given a [RequestId] and [ServerRequest] returns a list of ephemeral public keys derived from the input data (digest and r) for the ZKP.
+ */
+
+fun interface PostZkpJwkRequest {
+    context(Raise<ZkpJwkError>)
+    suspend operator fun invoke(request: ServerRequest, requestId: RequestId): List<EphemeralKeyResponse>
+}
+
+class PostZkpJwkRequestLive(
+    private val loadPresentationByRequestId: LoadPresentationByRequestId,
+    private val storePresentation: StorePresentation,
+) : PostZkpJwkRequest {
+
+
+    context(Raise<ZkpJwkError>)
+    override suspend operator fun invoke(request: ServerRequest, requestId: RequestId): List<EphemeralKeyResponse> {
+
+        val pem = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", "")
+        val keyBytes = Base64.getDecoder().decode(pem)
+        val keySpec = X509EncodedKeySpec(keyBytes)
+        val keyFactory = KeyFactory.getInstance("EC")
+        val publicKey = keyFactory.generatePublic(keySpec) as ECPublicKey
+
+        val verifier = ZKPVerifier(publicKey)
+        val presentation = loadPresentationByRequestId(requestId)
+
+        val challengeRequests = request.awaitBody<Array<ChallengeRequest>>()
+
+        return challengeRequests.map { challengeRequest ->
+            val challengeRequestData = ChallengeRequestData(digest = challengeRequest.digest, r = challengeRequest.r)
+            val (challenge, key) = verifier.createChallenge(challengeRequestData)
+
+            val x = challenge.w.affineX.toString()
+            val y = challenge.w.affineY.toString()
+
+            if (presentation is Presentation.Submitted) {
+                val zkpStateResult = Presentation.ZkpState.zkpReady(presentation, key)
+                zkpStateResult.onSuccess { zkpState ->
+                    storePresentation(zkpState)
+                }.onFailure { error ->
+                    raise(ZkpJwkError.ProcessingError("Failed to create ZkpState", error))
+                }
+            }
+
+            EphemeralKeyResponse(
+                id = challengeRequest.id,
+                kid = challengeRequest.id,
+                kty = "EC",
+                crv = "P-256",
+                x = x,
+                y = y
+            )
+        }
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostZkpJwkRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/PostZkpJwkRequest.kt
@@ -49,7 +49,7 @@ data class EphemeralKeyResponse(
     val y: String,
 )
 
-private const val publicKeyPEM = """
+private const val issuerPublicKeyPEM = """
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsFu+Nl1NXvC8RM/IXiXLu8MVA7X7
 mXT3Jnvb5uHxK/5JZxi0wqzGQ11KjZvUF8Ftc/oGAzWdPmTwGEg5ZD293g==
@@ -72,7 +72,7 @@ class PostZkpJwkRequestLive(
 
     context(Raise<ZkpJwkError>)
     override suspend operator fun invoke(request: ServerRequest, requestId: RequestId): List<EphemeralKeyResponse> {
-        val pem = publicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", "")
+        val pem = issuerPublicKeyPEM.replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", "")
         val keyBytes = Base64.getDecoder().decode(pem)
         val keySpec = X509EncodedKeySpec(keyBytes)
         val keyFactory = KeyFactory.getInstance("EC")

--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/TimeoutPresentations.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/TimeoutPresentations.kt
@@ -44,6 +44,7 @@ class TimeoutPresentationsLive(
             is Presentation.Requested -> presentation.timedOut(clock).getOrNull()
             is Presentation.RequestObjectRetrieved -> presentation.timedOut(clock).getOrNull()
             is Presentation.Submitted -> presentation.timedOut(clock).getOrNull()
+            is Presentation.ZkpState -> presentation.timedOut(clock).getOrNull()
             is Presentation.TimedOut -> null
         }
         return timeout?.also { storePresentation(it) }

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
@@ -41,6 +41,10 @@ import org.springframework.context.support.GenericApplicationContext
 import org.springframework.core.annotation.AliasFor
 import org.springframework.core.io.ClassPathResource
 import org.springframework.test.context.ContextConfiguration
+import java.net.URI
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
 import java.security.KeyStore
 import java.time.Clock
 import java.time.Instant
@@ -64,6 +68,10 @@ object TestContext {
             RSAKey.load(keystore, "client-id", "".toCharArray())
         }
     }
+
+    class VpFormat
+    private val vpFormatExample = VpFormat()
+    private val vpFormats = mapOf("exampleFormat" to vpFormatExample)
     val clientMetaData = ClientMetaData(
         jwkOption = ByValue,
         idTokenSignedResponseAlg = JWSAlgorithm.RS256.name,
@@ -71,6 +79,17 @@ object TestContext {
         idTokenEncryptedResponseEnc = EncryptionMethod.A128CBC_HS256.name,
         subjectSyntaxTypesSupported = listOf("urn:ietf:params:oauth:jwk-thumbprint", "did:example", "did:key"),
         jarmOption = ParseJarmOptionNimbus(null, JWEAlgorithm.ECDH_ES.name, "A256GCM")!!,
+        vpFormats = vpFormats,
+        zkpOption = EmbedOption.byReference {
+            URL.of(
+                URI("tt"),
+                object : URLStreamHandler() {
+                    override fun openConnection(u: URL?): URLConnection {
+                        TODO("Not yet implemented")
+                    }
+                },
+            )
+        },
     )
     val jarSigningConfig: SigningConfig = SigningConfig(rsaJwk, JWSAlgorithm.RS256)
     val clientIdScheme = ClientIdScheme.X509SanDns("client-id", jarSigningConfig)

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/TestContext.kt
@@ -41,10 +41,6 @@ import org.springframework.context.support.GenericApplicationContext
 import org.springframework.core.annotation.AliasFor
 import org.springframework.core.io.ClassPathResource
 import org.springframework.test.context.ContextConfiguration
-import java.net.URI
-import java.net.URL
-import java.net.URLConnection
-import java.net.URLStreamHandler
 import java.security.KeyStore
 import java.time.Clock
 import java.time.Instant
@@ -69,9 +65,6 @@ object TestContext {
         }
     }
 
-    class VpFormat
-    private val vpFormatExample = VpFormat()
-    private val vpFormats = mapOf("exampleFormat" to vpFormatExample)
     val clientMetaData = ClientMetaData(
         jwkOption = ByValue,
         idTokenSignedResponseAlg = JWSAlgorithm.RS256.name,
@@ -79,17 +72,6 @@ object TestContext {
         idTokenEncryptedResponseEnc = EncryptionMethod.A128CBC_HS256.name,
         subjectSyntaxTypesSupported = listOf("urn:ietf:params:oauth:jwk-thumbprint", "did:example", "did:key"),
         jarmOption = ParseJarmOptionNimbus(null, JWEAlgorithm.ECDH_ES.name, "A256GCM")!!,
-        vpFormats = vpFormats,
-        zkpOption = EmbedOption.byReference {
-            URL.of(
-                URI("tt"),
-                object : URLStreamHandler() {
-                    override fun openConnection(u: URL?): URLConnection {
-                        TODO("Not yet implemented")
-                    }
-                },
-            )
-        },
     )
     val jarSigningConfig: SigningConfig = SigningConfig(rsaJwk, JWSAlgorithm.RS256)
     val clientIdScheme = ClientIdScheme.X509SanDns("client-id", jarSigningConfig)
@@ -105,6 +87,7 @@ object TestContext {
         verifierConfig: VerifierConfig,
         requestJarByReference: EmbedOption.ByReference<RequestId>,
         presentationDefinitionByReference: EmbedOption.ByReference<RequestId>,
+        zkpOption: EmbedOption.ByReference<RequestId>,
     ): InitTransaction =
         InitTransactionLive(
             generatedTransactionId,
@@ -117,6 +100,8 @@ object TestContext {
             requestJarByReference,
             presentationDefinitionByReference,
             CreateQueryWalletResponseRedirectUri.Simple,
+            zkpOption,
+
         )
 
     fun getRequestObject(verifierConfig: VerifierConfig, presentationInitiatedAt: Instant): GetRequestObject =

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransactionTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/InitTransactionTest.kt
@@ -58,6 +58,7 @@ class InitTransactionTest {
                 verifierConfig,
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
+                EmbedOption.byReference { _ -> uri },
             )
 
             val jwtSecuredAuthorizationRequest = either { useCase(input) }.getOrElse { fail("Unexpected $it") }
@@ -91,6 +92,7 @@ class InitTransactionTest {
 
             val useCase = TestContext.initTransaction(
                 verifierConfig,
+                EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
             )
@@ -146,6 +148,7 @@ class InitTransactionTest {
                 verifierConfig,
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
+                EmbedOption.byReference { _ -> uri },
             )
 
             val jwtSecuredAuthorizationRequest = either { useCase(input) }.getOrElse { fail("Unexpected $it") }
@@ -171,6 +174,7 @@ class InitTransactionTest {
 
             val useCase: InitTransaction = TestContext.initTransaction(
                 verifierConfig,
+                EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
             )
@@ -200,6 +204,7 @@ class InitTransactionTest {
                 verifierConfig,
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
+                EmbedOption.byReference { _ -> uri },
             )
 
             // we expect the Authorization Request to contain a request that contains a presentation_definition_uri
@@ -219,6 +224,7 @@ class InitTransactionTest {
         runTest {
             val useCase: InitTransaction = TestContext.initTransaction(
                 verifierConfig,
+                EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
             )
@@ -277,6 +283,7 @@ class InitTransactionTest {
                 verifierConfig,
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
+                EmbedOption.byReference { _ -> uri },
             )
 
             either { useCase(input) }.getOrElse { fail("Unexpected $it") }
@@ -297,6 +304,7 @@ class InitTransactionTest {
 
             val useCase: InitTransaction = TestContext.initTransaction(
                 verifierConfig,
+                EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
                 EmbedOption.byReference { _ -> uri },
             )


### PR DESCRIPTION
This pr adds the first two steps of the [ZKP library](https://github.com/TICESoftware/ZKP) implementation.

1. It adds additional data to the `client_metadata` in the `presentation_definition `. 
2. It adds a new route for the wallet to fetch ephemeral keys necessary for the ZKP.

Furthermore, it adds a new state for saving the presentation to include the `privateKey`generated while calling ` val (challenge, key) = verifier.createChallenge(challengeRequestData)`. 